### PR TITLE
Use await in case of asynchronous method or fallback.

### DIFF
--- a/packages/decorators/src/utils.ts
+++ b/packages/decorators/src/utils.ts
@@ -78,7 +78,7 @@ export function createFunctionPrecondition(precondition: FunctionPrecondition, f
 
 		descriptor.value = async function descriptorValue(this: (...args: any[]) => any, ...args: any[]) {
 			const canRun = await precondition(...args);
-			return canRun ? method.call(this, ...args) : fallback.call(this, ...args);
+			return canRun ? await method.call(this, ...args) : await fallback.call(this, ...args);
 		} as unknown as undefined;
 	});
 }


### PR DESCRIPTION
In case the method or fallback is async, not using `await` will result the return of Promise resulting in a false value making the function not work.